### PR TITLE
Add roles, templates, and checklists to project management docs

### DIFF
--- a/docs/docs_README_Version2.md
+++ b/docs/docs_README_Version2.md
@@ -1,0 +1,26 @@
+# Project Management Docs (OctoAcme)
+
+This folder contains project management process documents, templates, and checklists to help teams run predictable projects for OctoAcme.
+
+Included in this change:
+- octoacme-roles-and-personas.md — Adds new personas (Release Manager, Risk Coordinator, Communications Lead, Data Analyst, Stakeholder Liaison) and clarifies interactions with existing roles.
+- octoacme-release-checklist.md — Practical pre-release checklist and go/no-go guidance.
+- octoacme-risk-register-template.md — Risk register template, how-to, and escalation guidance.
+- octoacme-communication-plan-template.md — Communication plan template and approval flow.
+
+Why these changes
+-----------------
+These documents close gaps identified in issue #4 by:
+- Assigning clearer ownership for releases, risks, and communications.
+- Providing practical templates that teams can apply immediately.
+- Improving consistency in reporting and escalation.
+
+How to apply
+------------
+1. Copy these files into docs/ in the repository.
+2. Reference octoacme-roles-and-personas.md from other process docs (planning, release, risk docs).
+3. Review with at least one Project Manager and one Engineering Lead before publishing.
+
+Change history
+--------------
+- 2025-11-08 — Added roles and templates to support issue #4.

--- a/docs/docs_octoacme-communication-plan-template_Version2.md
+++ b/docs/docs_octoacme-communication-plan-template_Version2.md
@@ -1,0 +1,42 @@
+# OctoAcme — Communication Plan Template
+
+Purpose
+-------
+Template to plan, coordinate, and approve project communications (internal and external).
+
+Communication Plan template
+---------------------------
+| Audience | Channel | Cadence | Owner | Purpose | Example Message | Approval Required |
+|----------|---------|---------|-------|---------|-----------------|-------------------|
+| Project Team | Slack / Email | Daily stand-up | Project Manager | Sync work & blockers | "Daily stand-up notes — today: ..." | No |
+| Steering Committee | Email / Doc | Bi-weekly | Project Manager | Senior status & decisions | "Status: Green — next milestones..." | Yes (PM + PO) |
+| Customers / External | Release notes / Newsletter | Per release | Communications Lead | Announce features & impact | "Release 1.2 notes: includes..." | Yes (Legal/Marketing) |
+| Operations / SRE | Runbook / Pager | As needed | Release Manager | Deployment coordination | "Deployment scheduled for..." | No |
+
+Sections to include
+-------------------
+- Audiences: who needs to know.
+- Channels: where messages will be posted (Slack, email, Confluence, docs).
+- Cadence: frequency (daily, weekly, per milestone).
+- Owner: who drafts and publishes.
+- Purpose: why the audience needs the update.
+- Approval: approvals needed before publishing.
+
+Example messages
+----------------
+- Weekly status (internal): summary of accomplishments, upcoming work, blockers.
+- Release notice (external): scope, impact, mitigation, and support contacts.
+- Incident update (external): short facts, impact, ETA, and recovery steps.
+
+Approval flow (example)
+-----------------------
+1. Draft by Communications Lead / Release Manager.
+2. Review by Project Manager and Product Owner.
+3. External communications require Legal/Marketing signoff where applicable.
+4. Publish and archive message in project docs.
+
+How to use
+----------
+- Populate the table at project kickoff and keep it updated.
+- Attach example messages and templates for common scenarios to reduce churn.
+- Use the Communications Lead for consistency and to avoid mixed messages.

--- a/docs/docs_octoacme-release-checklist_Version2.md
+++ b/docs/docs_octoacme-release-checklist_Version2.md
@@ -1,0 +1,61 @@
+# OctoAcme — Release Checklist
+
+Purpose
+-------
+A practical pre-release checklist to be used by Release Manager and Project Manager to ensure releases are safe, predictable, and well-communicated.
+
+Owner
+-----
+Primary: Release Manager
+Informed: Project Manager, Engineering Lead, QA Lead, Ops
+
+Timing and checkpoints
+----------------------
+- T-48 hours: Release readiness review (high-level)
+- T-24 hours: Detailed pre-release checklist run
+- T-1 hour: Final runbook & monitoring check
+- Deployment window: Go/No-Go meeting and execution
+- Post-deploy (T+1 hour, T+24 hours): Verify monitoring and rollback markers
+
+Pre-release checklist (example)
+-------------------------------
+- Release calendar entry published and stakeholders informed.
+- Release notes drafted and reviewed.
+- Feature list validated and release scope confirmed.
+- QA signoffs completed (regression, acceptance tests).
+- Security scans completed and critical issues resolved or accepted with mitigations.
+- Database migrations planned, reviewed, and rollback steps verified.
+- Deployment runbook ready and reviewed with Ops/SRE.
+- Rollback plan and smoke tests prepared.
+- Monitoring/alerting configured for post-release checks.
+- Feature flags / toggles reviewed and validated.
+- Backups / snapshots created where applicable.
+- Approvals captured (as per governance).
+- Communications plan for the release drafted (internal & external).
+
+Go / No-Go meeting (example agenda)
+----------------------------------
+1. Review release scope and critical changes.
+2. Confirm QA and security signoffs.
+3. Confirm Ops readiness and deployment window.
+4. Review rollback plan and monitoring.
+5. Final list of known risks / mitigations.
+6. Vote/decision (Release Manager recommends, Project Manager approves).
+
+Post-release
+------------
+- Confirm post-deploy smoke tests pass.
+- Monitor metrics for regressions (error rate, latency, key transactions).
+- Publish release summary and retrospective notes.
+- If issues occur, follow rollback/runbook and conduct incident retrospective.
+
+Customization notes
+-------------------
+- For small projects, PM may act as Release Manager.
+- For high-risk or high-visibility releases, increase cadence of readiness checks and require stakeholder signoff.
+
+Template: Ownership and timing (example)
+- T-48h: Release Manager — run readiness; notify stakeholders
+- T-24h: Release Manager — confirm QA signoffs; Ops runbook review
+- T-1h: Ops/Release Manager — final checks
+- Deploy: Release Manager + Ops — execute; Project Manager — communicate

--- a/docs/docs_octoacme-risk-register-template_Version2.md
+++ b/docs/docs_octoacme-risk-register-template_Version2.md
@@ -1,0 +1,42 @@
+# OctoAcme — Risk Register Template & Guidance
+
+Purpose
+-------
+A simple, consistent risk register template and guidance to support identification, tracking, and mitigation of project risks.
+
+Risk Register (table template)
+------------------------------
+| ID | Description | Owner | Impact (H/M/L) | Likelihood (H/M/L) | Priority | Mitigation / Action | Status | Detection Date | Review Cadence |
+|----|-------------|-------|----------------|---------------------|----------|---------------------|--------|----------------|----------------|
+| R-001 | Short description of the risk | Name (role) | H | M | High | Steps to mitigate or reduce impact | Open / Mitigated / Closed | YYYY-MM-DD | Weekly / Monthly |
+
+Fields explained
+--------------
+- ID: Unique risk identifier (R-001, R-002, etc.).
+- Description: Concise description of the risk scenario and potential impact.
+- Owner: Person/role responsible for tracking and executing mitigation.
+- Impact: Severity if the risk materializes (High / Medium / Low).
+- Likelihood: Probability of occurrence (High / Medium / Low).
+- Priority: Derived from impact & likelihood (High/Medium/Low).
+- Mitigation / Action: Specific steps to reduce likelihood or impact; contingency plan.
+- Status: Current status (Open, Monitoring, Mitigated, Closed).
+- Detection Date: When the risk was first logged.
+- Review Cadence: How often the risk will be reviewed (e.g., weekly).
+
+How-to & governance
+-------------------
+- Maintain one register per project (or per major release for larger programs).
+- Hold a weekly risk triage meeting (led by Risk Coordinator or PM) to:
+  - Review new risks and assign ownership
+  - Update mitigation progress
+  - Escalate high-priority items to PMO or steering committee
+- Create a risk heatmap for quarterly steering reviews for portfolio-level visibility.
+
+Escalation guidance
+-------------------
+- Escalate to Project Manager when a risk becomes high priority or mitigation requires schedule/financial trade-offs.
+- Escalate to PMO/Governance when risks impact cross-project dependencies or portfolio commitments.
+
+Example entry
+-------------
+| R-001 | Backend database schema migration may cause downtime | Engineering Lead | H | M | High | Create migration with blue-green approach; pre-run on staging; rollback snapshot | Open | 2025-11-01 | Weekly |

--- a/docs/docs_octoacme-roles-and-personas_Version2.md
+++ b/docs/docs_octoacme-roles-and-personas_Version2.md
@@ -1,0 +1,182 @@
+# OctoAcme — Roles and Personas
+
+Purpose
+-------
+This document lists the project roles and personas used across OctoAcme project management processes. It defines responsibilities, interactions with existing roles, decision authority (where applicable), and examples of activities. Use this document to clarify accountability, avoid overlaps, and speed onboarding.
+
+Scope
+-----
+Applies to all OctoAcme projects and supplements the project management process documents (initiation, planning, execution, risks & communication, release & deployment, retrospective). New personas below are intended to complement existing roles (Project Manager, Product Owner, Engineering Lead, QA Lead, Architects, Devs, Ops, and Stakeholders).
+
+Guidelines for use
+------------------
+- Each project may assign one or more personas depending on size and complexity.
+- Where responsibilities overlap, assign a primary owner and a secondary/backfill.
+- Document assigned people and contact points in the project charter.
+
+New / Clarified Personas
+------------------------
+
+### Release Manager
+Summary:
+Oversees release planning, orchestration, and delivery; ensures release quality, compliance, and communication.
+
+Responsibilities:
+- Maintain and publish release calendar and cutoffs.
+- Coordinate cross-team release readiness activities (code freeze, migrations, feature toggles).
+- Verify that release criteria (QA signoffs, security scans, configuration, rollback plans) are met.
+- Escalate release blockers and facilitate resolution.
+- Coordinate deployment windows with Ops and stakeholders.
+
+Interacts with:
+- Project Manager: align release timeline with project milestones.
+- Development / Engineering Lead: verify release contents and readiness.
+- QA Lead: obtain test signoffs and regression results.
+- Ops / SRE: coordinate deployment runbooks and rollback procedures.
+- Communications Lead: prepare release notices.
+
+Decision Authority:
+- Approves (or postpones) release go/no-go based on defined criteria.
+
+Example activities:
+- Run release readiness checklist 48 hours before deployment.
+- Facilitate go/no-go meeting and publish release notes.
+
+---
+
+### Risk Coordinator
+Summary:
+Central point for identifying, tracking, and managing project risks and mitigations.
+
+Responsibilities:
+- Maintain a project risk register and coordinate regular risk reviews.
+- Ensure each risk has an owner, impact, likelihood, and mitigation plan.
+- Facilitate cross-functional workshops for risk identification and escalation.
+- Track mitigation status and surface unresolved high-impact risks to leadership.
+
+Interacts with:
+- Project Manager: ensure risks are reflected in project plan and schedule.
+- Architects / Engineering Lead: technical risk assessment and mitigation.
+- Product Owner / Stakeholder Liaison: business and stakeholder-related risk identification.
+- PMO / Governance: escalate risks that impact portfolio-level decisions.
+
+Decision Authority:
+- Nominates risk owners and recommends escalations; escalation decisions follow project governance.
+
+Example activities:
+- Weekly risk triage meeting and updates to the project dashboard.
+- Produce risk heatmap for steering committee.
+
+---
+
+### Communications Lead
+Summary:
+Manages internal and external communication strategy and artifacts for the project.
+
+Responsibilities:
+- Maintain communication plan, including cadence, channels, and audience mapping.
+- Draft and publish status updates, stakeholder briefings, and release communications.
+- Ensure messaging consistency across teams and documents.
+- Coordinate stakeholder meetings, demos, and town-hall briefings.
+
+Interacts with:
+- Project Manager: align messaging with project status and key milestones.
+- Stakeholder Liaison: validate stakeholder messaging and expectations.
+- Release Manager: coordinate release announcements.
+- Marketing / Legal (if applicable): approve external-facing communications.
+
+Decision Authority:
+- Approves communication templates and publishing cadence; final signoff for external comms may require stakeholder or legal approval.
+
+Example activities:
+- Create and distribute weekly status bulletin.
+- Draft customer-facing release notes with Release Manager.
+
+---
+
+### Data Analyst (Project Metrics)
+Summary:
+Provides quantitative insight into project performance through metrics, dashboards, and trend analysis.
+
+Responsibilities:
+- Define and track key project metrics (velocity, cycle time, defect rates, test coverage, deployment frequency).
+- Build and maintain dashboards and periodic reports.
+- Analyze trends and provide recommendations to improve delivery predictability.
+- Validate data used in stakeholder reporting.
+
+Interacts with:
+- Project Manager: provide status metrics and forecasts.
+- QA Lead: collect quality metrics and defect trend analysis.
+- Engineering Lead: share engineering productivity and bottleneck analyses.
+- Risk Coordinator: support data-driven risk identification.
+
+Decision Authority:
+- Advises on metric definitions and triggers for corrective action; does not unilaterally change project plan.
+
+Example activities:
+- Weekly metrics dashboard update and a short interpretation note.
+- Run root-cause analysis on growing defect trends.
+
+---
+
+### Stakeholder Liaison
+Summary:
+Primary contact for stakeholder engagement; translates stakeholder needs to the project team and ensures stakeholder expectations are managed.
+
+Responsibilities:
+- Maintain stakeholder register and communication preferences.
+- Collect stakeholder feedback and issues; route to appropriate owners.
+- Prepare stakeholder-specific briefings and approvals.
+- Manage expectation alignment when scope or schedule changes are proposed.
+
+Interacts with:
+- Product Owner / Project Manager: translate stakeholder priorities into backlog/plan items.
+- Communications Lead: ensure stakeholder messaging is clear and tailored.
+- Risk Coordinator: bring stakeholder concerns into risk discussions.
+
+Decision Authority:
+- Can request escalations or pause non-critical activities pending stakeholder clarification; final decisions follow governance.
+
+Example activities:
+- Run stakeholder feedback sessions after demos.
+- Prepare summarized stakeholder feedback for the PM and Product Owner.
+
+---
+
+Clarifying interactions with existing roles
+-------------------------------------------
+- Project Manager (PM): central integrator. PM coordinates planning, dependencies, and schedules. New personas provide domain-specific execution and information (e.g., Release Manager handles the operational release checklist while PM ensures release fits the plan).
+- Product Owner (PO): prioritizes scope and features. Stakeholder Liaison and Communications Lead help align external expectations with the PO.
+- Engineering / QA Leads: retain technical and quality ownership. Risk Coordinator and Data Analyst support their decisions with risk assessments and metrics.
+- Ops / SRE: own production stability. Release Manager must coordinate deployment mechanics with Ops.
+
+Suggested RACI pattern (example)
+--------------------------------
+- Release planning: R=Release Manager, A=Project Manager, C=Engineering Lead / QA Lead / Ops, I=Stakeholders
+- Risk register maintenance: R=Risk Coordinator, A=Project Manager, C=All team leads, I=Stakeholders
+- Stakeholder updates: R=Communications Lead / Stakeholder Liaison, A=Project Manager, C=Product Owner, I=Stakeholders
+
+How these personas improve outcomes
+----------------------------------
+- Clear ownership reduces handoff delays (Release Manager for releases; Risk Coordinator for risks).
+- Better stakeholder alignment reduces rework and late-scope changes (Stakeholder Liaison).
+- Data-driven interventions help catch trends early and improve predictability (Data Analyst).
+- Consistent messaging reduces confusion and increases trust (Communications Lead).
+
+Acceptance Criteria (for adding these personas to process docs)
+---------------------------------------------------------------
+- Content aligns with the structure and language of existing process documents.
+- Each persona has a clear set of responsibilities and named interactions with existing roles.
+- Example activities and decision authorities are included to support implementation.
+- Document reviewed by at least one PM and one engineering lead for accuracy.
+
+Next steps & governance
+-----------------------
+1. Review this draft with the PM and Engineering lead for the project(s) that will adopt these personas.
+2. Adjust responsibilities to reflect project size (e.g., in small projects, personas may be combined).
+3. Publish under docs/ and reference from octoacme-project-planning.md and octoacme-release-and-deployment.md.
+4. Track adoption feedback during the next retrospective and iterate.
+
+Change history
+--------------
+- 2025-11-08 — Initial draft adding Release Manager, Risk Coordinator, Communications Lead, Data Analyst, and Stakeholder Liaison.


### PR DESCRIPTION
Summary
This PR implements process improvements requested in issue #4 (Adding more personas and roles to the project management processes). It adds a roles & personas document and a set of practical templates/checklists to make release, risk, and communication processes explicit and actionable.

Files added
docs/octoacme-roles-and-personas.md
Adds Release Manager, Risk Coordinator, Communications Lead, Data Analyst (Project Metrics), and Stakeholder Liaison personas. Responsibilities, interactions with existing roles, example activities, decision authorities, suggested RACI, acceptance criteria. docs/octoacme-release-checklist.md
Practical pre-release checklist, timing (48h/24h/1h), go/no-go meeting agenda, post-release steps. docs/octoacme-risk-register-template.md
Risk register table template, field explanations, weekly triage guidance, escalation rules, example entry. docs/octoacme-communication-plan-template.md
Communication plan template (audience, channel, cadence, owner), example messages, approval flow. docs/README.md
Index and short summary of changes and instructions for adoption. Why these changes
Addresses gaps in ownership and operationalization of releases and risks (issue #4). Provides ready-to-use templates to reduce friction and increase consistency. Supports data-driven decision making and clearer stakeholder communication. Acceptance criteria for this PR
Content aligns with existing process docs (language/structure) and is placed under docs/. Each persona includes responsibilities, interactions, and example activities. Templates include practical guidance (timing, owners, approval flows). At least one Project Manager and one Engineering Lead review the PR prior to merge. Assumptions
Repo uses docs/ as a place for process docs (confirmed by template). No automated docs generation or strong frontmatter requirements are enforced; if required, I can add frontmatter on request. Small projects may combine personas; the docs note that. Linked issue
Refs #4
Reviewers
Please add gonzalochief as a reviewer.
How you can apply these changes (manual steps)

Option A: If you have local repo access

Create a branch: git checkout -b docs/add-roles-templates Add files under docs/ with the content above.
Commit and push: git add docs/* && git commit -m "Add roles, templates, and checklists to project management docs" && git push --set-upstream origin docs/add-roles-templates Open a PR via GitHub UI or gh cli using the PR title/body above, assign reviewer gonzalochief, and reference issue #4. Option B: Use GitHub web UI to create each new file under docs/ and then open a PR with the title/body above.

If you want, I can:

produce a single unified patch (diff) you can apply with git apply, produce the exact gh CLI commands to create the branch and PR, or (if you give me repo PR creation permission from this environment) create the PR and add the reviewer.